### PR TITLE
use std::thread::spawn and a tokio::task::spawn_local

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,7 @@ where
     H: Handler + Debug + Send + 'static,
 {
     Curl(curl::Error),
+    Multi(curl::MultiError),
     TokioRecv(RecvError),
     TokioSend(SendError<actor::Request<H>>),
 }
@@ -59,6 +60,7 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Error::Curl(err) => write!(f, "{}", err),
+            Error::Multi(err) => write!(f, "{}", err),
             Error::TokioRecv(err) => write!(f, "{}", err),
             Error::TokioSend(err) => write!(f, "{}", err),
         }


### PR DESCRIPTION
This is to ensure to avoid blocking of other task
in the tokio runtime.

Curl Multi was used to perform Curl since it will
perform in a non-blocking way.