### PR TITLE
Add new_runtime method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 async-trait = "0.1"
 curl = "0.4"
 log = "0.4"
-tokio = { version = "1.45", features = ["rt", "test-util", "macros"] }
+tokio = { version = "1.45", features = ["rt", "rt-multi-thread", "test-util", "macros"] }
 
 [dev-dependencies]
 ctor = "0.4"


### PR DESCRIPTION
This creates the new instance of CurlActor to handle Curl perform asynchronously using Curl Multi in a background thread to avoid blocking of other tasks. The user can provide a custom runtime to use for the background task.