### PR TITLE
Re-export curl-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ readme = "README.md"
 [dependencies]
 async-trait = "0.1"
 curl = "0.4"
+curl-sys = "0.4"
 log = "0.4"
 tokio = { version = "1.49", features = ["rt", "rt-multi-thread", "test-util", "macros"] }
 
 [dev-dependencies]
 ctor = "1.0"
-curl-sys = "0.4.89"
 env_logger = "0.11"
 http = "1.4"
 wiremock = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,4 +85,5 @@ pub use error::*;
 
 pub mod dep {
     pub use curl;
+    pub use curl_sys;
 }


### PR DESCRIPTION
This is to use some curl error codes
without adding curl-sys to the user of this crate.